### PR TITLE
Fixed check on dataMap in JSONRequest. Added tests to check setData

### DIFF
--- a/http/client/src/main/java/io/higgs/http/client/JSONRequest.java
+++ b/http/client/src/main/java/io/higgs/http/client/JSONRequest.java
@@ -73,7 +73,7 @@ public class JSONRequest extends Request<JSONRequest> {
      * @throws java.lang.IllegalStateException if {@link #addField(String, Object)} has been used to add any fields
      */
     public JSONRequest setData(String data) {
-        if (dataMap != null) {
+        if (!dataMap.isEmpty()) {
             throw new IllegalStateException("You cannot use setData in combination with addField");
         }
         if (data == null) {
@@ -92,7 +92,7 @@ public class JSONRequest extends Request<JSONRequest> {
      * @throws java.lang.IllegalStateException if {@link #addField(String, Object)} has been used to add any fields
      */
     public JSONRequest setData(Object data) throws JsonProcessingException {
-        if (dataMap != null) {
+        if (!dataMap.isEmpty()) {
             throw new IllegalStateException("You cannot use setData in combination with addField");
         }
         if (data == null) {

--- a/http/client/src/test/java/io/higgs/http/client/JSONRequestTest.java
+++ b/http/client/src/test/java/io/higgs/http/client/JSONRequestTest.java
@@ -24,6 +24,18 @@ public class JSONRequestTest {
         uri = new URI("http://httpbin.org");
     }
 
+    @Test
+    public void setContentUsingSetDataStr() {
+        HttpRequestBuilder.instance().postJSON(uri, reader)
+                .setData("{}");
+    }
+
+    @Test
+    public void setContentUsingSetDataObj() throws JsonProcessingException {
+        HttpRequestBuilder.instance().postJSON(uri, reader)
+                .setData(map);
+    }
+
     @Test(expected = IllegalStateException.class)
     public void throwIllegalStateIfAddFieldCalledAfterSetDataStr() throws JsonProcessingException {
         HttpRequestBuilder.instance().postJSON(uri, reader)


### PR DESCRIPTION
IllegalStateException seems to currently be thrown 100% of the time when calling setData() in the new JSONRequest class. The method currently checks for null to indicate an empty request map. dataMap is instantiated as a HashMap object on construction of the class, so will never equal null.

The condition has been modified to use isEmpty(). I've added simple tests to check that calling the method with a String or an Object does not throw an exception.